### PR TITLE
Update Ad Intelligence project metadata

### DIFF
--- a/src/data/portfolioData.ts
+++ b/src/data/portfolioData.ts
@@ -53,9 +53,9 @@ export const personalInfo = {
 export const projects: Project[] = [
   {
     id: "avent-intelligence",
-    title: "Avent Ad Intelligence Dashboard",
-    description: "End-to-end multimedia analytics dashboard built to collect ads, Instagram/TikTok posts, and Amazon reviews, download all images/videos, and classify breast pump content using the Gemini API for image understanding.",
-    technologies: ["React", "TypeScript", "Python", "Gemini API"],
+    title: "Ad Intelligence Marketplace Insights",
+    description: "End-to-end multimedia analytics dashboard that collects ads, Instagram/TikTok posts, and Amazon reviews, downloads all images/videos, and classifies breast pump content using the Gemini API for image understanding to visualize market dynamics.",
+    technologies: ["React", "TypeScript", "Python", "Gemini API", "Computer Vision", "Sentiment Analysis"],
     link: "https://avent-three.vercel.app/",
     category: "dashboard",
     featured: true


### PR DESCRIPTION
## Summary
- Rename the Avent project entry to Ad Intelligence Marketplace Insights to better reflect its focus
- Clarify the project description around multimedia classification and market visualization
- Update technology tags to emphasize computer vision and sentiment analysis instead of chatbot capabilities

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69588f5fdc44832892a9448fbc95d168)