### PR TITLE
Update portfolio experience to 5+ years

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -18,7 +18,7 @@ const About: React.FC = () => {
           <div className="space-y-6">
             <p className="text-sm md:text-base text-gray-600 leading-relaxed text-justify">
               Economist with emphasis in Behavioral Economics and a Master's in Biostatistics and 
-              Bioinformatics, currently working as a Senior Data Analyst. With <strong>3+ years of experience</strong> 
+              Bioinformatics, currently working as a Senior Data Analyst. With <strong>5+ years of experience</strong>
               across public and private sectors in industries like transportation, telecommunications, 
               marketing, and startups.
             </p>

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -18,7 +18,7 @@ const Experience: React.FC = () => {
             Professional <span className="gradient-text">Experience</span>
           </h2>
           <p className="text-sm md:text-base text-gray-600 leading-relaxed text-justify max-w-3xl mx-auto">
-            3+ years of hands-on experience in advanced data analytics and interactive dashboard development, 
+            5+ years of hands-on experience in advanced data analytics and interactive dashboard development,
             collaborating with cross-functional teams in hospitality, advertising, and emerging technology markets 
             to deliver scalable analytics solutions that drive measurable business outcomes.
           </p>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -303,7 +303,7 @@ const Hero: React.FC = () => {
               className="bg-white/60 backdrop-blur-sm rounded-2xl p-4 shadow-lg hover:shadow-xl transition-all duration-300"
             >
               <h3 className="text-2xl md:text-3xl font-bold gradient-text mb-2">
-                3+
+                5+
               </h3>
               <p className="text-gray-600 font-medium text-xs md:text-sm">Years Experience</p>
             </motion.div>


### PR DESCRIPTION
## Summary
- update professional experience descriptions to reflect 5+ years
- adjust hero statistics card to show 5+ years experience

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69589b197acc832881643f050c0ed1e0)